### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 
 .DS_Store
+bin/
+skylib/
+**/_dist_/
+*.6 
+
+skygen/skygen
+
+skygen/bin/skygen

--- a/examples/GetWidgets/watchers/reaper/reaper.go
+++ b/examples/GetWidgets/watchers/reaper/reaper.go
@@ -30,7 +30,7 @@ func monitorServices() {
 				x, err := rpc.DialHTTP("tcp", portString)
 				if err != nil {
 					log.Println("BAD CON:", err)
-					v.RemoveFromConfig()
+					skylib.RemoveFromConfig(v)
 					skylib.Errors.Add(1)
 					break
 				}

--- a/skylib/config.go
+++ b/skylib/config.go
@@ -64,7 +64,7 @@ func GetRandomClientByProvides(provides string) (*rpc.Client, os.Error) {
 		newClient, err = rpc.DialHTTP("tcp", hostString)
 		if err != nil {
 			LogWarn(fmt.Sprintf("Found %d Services to service %s request on %s.",
-				len(serviceList), provides, portString))
+				len(serviceList), provides, hostString))
 			return nil, NewError(NO_CLIENT_PROVIDES_SERVICE, provides)
 		}
 

--- a/skylib/service.go
+++ b/skylib/service.go
@@ -1,0 +1,69 @@
+//Copyright (c) 2011 Brian Ketelsen
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+package skylib
+
+import (
+	"os"
+	"time"
+)
+
+// A Generic struct to represent any service in the SkyNet system.
+type Service struct {
+	IPAddress string
+	Name      string
+	Port      int
+	Provides  string
+}
+
+// Exported RPC method for the health check
+func (hc *Service) Ping(hr *HeartbeatRequest, resp *HeartbeatResponse) (err os.Error) {
+
+	resp.Timestamp = time.Seconds()
+
+	return nil
+}
+
+// Exported RPC method for the advanced health check
+func (hc *Service) PingAdvanced(hr *HealthCheckRequest, resp *HealthCheckResponse) (err os.Error) {
+
+	resp.Timestamp = time.Seconds()
+	resp.Load = 0.1 //todo
+	return nil
+}
+
+func (r *Service) Equal(that *Service) bool {
+	var b bool
+	b = false
+	if r.Name != that.Name {
+		return b
+	}
+	if r.IPAddress != that.IPAddress {
+		return b
+	}
+	if r.Port != that.Port {
+		return b
+	}
+	if r.Provides != that.Provides {
+		return b
+	}
+	b = true
+	return b
+}
+
+// Utility function to return a new Service struct
+// pre-populated with the data on the command line.
+func NewService(provides string) *Service {
+	r := &Service{
+		Name:      *Name,
+		Port:      *Port,
+		IPAddress: *BindIP,
+		Provides:  provides,
+	}
+
+	return r
+}

--- a/skylib/types.go
+++ b/skylib/types.go
@@ -10,6 +10,7 @@ package skylib
 import (
 	"fmt"
 	"container/vector"
+	"os"
 )
 
 
@@ -100,12 +101,12 @@ func NewError(msg string, service string) (err *Error) {
 // CheckError is a deferred function to turn a panic with type *Error into a plain error return.
 // Other panics are unexpected and so are re-enabled.
 func CheckError(error *os.Error) {
-    if v := recover(); v != nil {
-        if e, ok := v.(*Error); ok {
-            *error = e
-        } else {
-            // runtime errors should crash
-            panic(v)
-        }
-    }
+	if v := recover(); v != nil {
+		if e, ok := v.(*Error); ok {
+			*error = e
+		} else {
+			// runtime errors should crash
+			panic(v)
+		}
+	}
 }

--- a/skylib/types.go
+++ b/skylib/types.go
@@ -8,10 +8,7 @@
 package skylib
 
 import (
-	"os"
-	"time"
 	"fmt"
-	"rpc"
 	"container/vector"
 )
 
@@ -29,15 +26,6 @@ type RpcService struct {
 
 func (r *RpcService) parseError(err string) {
 	panic(&Error{err, r.Provides})
-}
-
-
-// A Generic struct to represent any service in the SkyNet system.
-type Service struct {
-	IPAddress string
-	Name      string
-	Port      int
-	Provides  string
 }
 
 
@@ -96,63 +84,6 @@ type NetworkServers struct {
 type ServerConfig interface {
 	Equal(that interface{}) bool
 }
-
-// Exported RPC method for the health check
-func (hc *Service) Ping(hr *HeartbeatRequest, resp *HeartbeatResponse) (err os.Error) {
-
-	resp.Timestamp = time.Seconds()
-
-	return nil
-}
-
-// Exported RPC method for the advanced health check
-func (hc *Service) PingAdvanced(hr *HealthCheckRequest, resp *HealthCheckResponse) (err os.Error) {
-
-	resp.Timestamp = time.Seconds()
-	resp.Load = 0.1 //todo
-	return nil
-}
-
-// Method to register the heartbeat of each skynet
-// client with the healthcheck exporter.
-func RegisterHeartbeat() {
-	r := NewService("Service.Ping")
-	rpc.Register(r)
-}
-
-
-func (r *Service) Equal(that *Service) bool {
-	var b bool
-	b = false
-	if r.Name != that.Name {
-		return b
-	}
-	if r.IPAddress != that.IPAddress {
-		return b
-	}
-	if r.Port != that.Port {
-		return b
-	}
-	if r.Provides != that.Provides {
-		return b
-	}
-	b = true
-	return b
-}
-
-// Utility function to return a new Service struct
-// pre-populated with the data on the command line.
-func NewService(provides string) *Service {
-	r := &Service{
-		Name:      *Name,
-		Port:      *Port,
-		IPAddress: *BindIP,
-		Provides:  provides,
-	}
-
-	return r
-}
-
 
 type Error struct {
 	Msg     string


### PR DESCRIPTION
Refactoring: service.go now concentrates all stuff related to Skynet
Services. `RemoveFromConfig` and `AddToConfig` now takes a `Service` as arg.
RegisterHeartbeat moved to config.go leaving types.go with just types.

`config.go/GetRandomClientByProvides` received some cleanner var names.
