### PR TITLE
fibonacci service

### DIFF
--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -12,12 +12,7 @@ import (
 func main() {
 	c := make(chan os.Signal, 1)
 
-	config := &skynet.ClientConfig{
-		DoozerConfig: &skynet.DoozerConfig{
-			Uri:          "127.0.0.1:8046",
-			AutoDiscover: true,
-		},
-	}
+	config, _ := skynet.GetClientConfigFromFlags(os.Args...)
 
 	var err error
 	config.Log = skynet.NewConsoleLogger(os.Stderr)

--- a/examples/testing/fibonacci/fibclient/fibclient.go
+++ b/examples/testing/fibonacci/fibclient/fibclient.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"github.com/bketelsen/skynet"
+	"github.com/bketelsen/skynet/client"
+	"github.com/bketelsen/skynet/examples/testing/fibonacci"
+	"os"
+	"strconv"
+)
+
+func main() {
+	config, args := skynet.GetClientConfigFromFlags(os.Args...)
+	client := client.NewClient(config)
+
+	service := client.GetService("Fibonacci", "", "", "")
+
+	for _, arg := range args[1:] {
+		index, err := strconv.Atoi(arg)
+		if err != nil {
+			panic(err)
+		}
+		req := fibonacci.Request{
+			Index: index,
+		}
+		resp := fibonacci.Response{}
+		err = service.Send(nil, "Index", req, &resp)
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Printf("%d -> %d\n", index, resp.Value)
+		}
+	}
+}

--- a/examples/testing/fibonacci/fibonacci.go
+++ b/examples/testing/fibonacci/fibonacci.go
@@ -1,0 +1,24 @@
+/*
+The fibonacci package serves as both an example of good skynet development
+practice (NOTE: IT IS YET TO BE DETERMINED WHAT GOOD SKYNET DEVELOPMENT
+PRACTICE IS) and a skynet stress tester. The service will act as a client
+and recursively call itself to solve the Fibonacci recurrence.
+
+By collecting the request and response parameters into two publicly
+accessible types, it is easy to make sure your client is giving the service
+the kind of data it expects, provided the expected version is used.
+*/
+package fibonacci
+
+type Request struct {
+	// The index of the value in the Fibonnaci sequence.
+	// F_0 = 0, F_1 = 1, F_{i+2} = F_{i+1} + F_i
+	Index int
+}
+
+type Response struct {
+	// The index of the value in the Fibonacci sequence.
+	Index int
+	// The numerical value corresponding to the index.
+	Value uint64
+}

--- a/examples/testing/fibonacci/fibservice/fibservice.go
+++ b/examples/testing/fibonacci/fibservice/fibservice.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/bketelsen/skynet"
+	"github.com/bketelsen/skynet/client"
+	"github.com/bketelsen/skynet/examples/testing/fibonacci"
+	"github.com/bketelsen/skynet/service"
+	"log"
+	"os"
+	"sync"
+)
+
+type Fibonacci struct {
+	cconfig *skynet.ClientConfig
+	client  *client.Client
+
+	// previously computed values
+	cache  map[int]chan uint64
+	cmutex sync.Mutex
+}
+
+func NewFibonacci() (f *Fibonacci) {
+	f = new(Fibonacci)
+
+	f.cconfig, _ = skynet.GetClientConfigFromFlags(os.Args...)
+	f.client = client.NewClient(f.cconfig)
+
+	f.cache = map[int]chan uint64{
+		0: make(chan uint64, 1),
+		1: make(chan uint64, 1),
+	}
+	f.cache[0] <- 0
+	f.cache[1] <- 1
+
+	return
+}
+
+func (f *Fibonacci) Registered(s *service.Service)   {}
+func (f *Fibonacci) Unregistered(s *service.Service) {}
+func (f *Fibonacci) Started(s *service.Service)      {}
+func (f *Fibonacci) Stopped(s *service.Service)      {}
+
+func (f *Fibonacci) Index(ri *skynet.RequestInfo, req fibonacci.Request, resp *fibonacci.Response) (err error) {
+	if req.Index < 0 {
+		err = errors.New(fmt.Sprintf("Invalid request: %+v", req))
+		return
+	}
+
+	resp.Index = req.Index
+
+	f.cmutex.Lock()
+	vchan, ok := f.cache[req.Index]
+	if ok {
+		f.cmutex.Unlock()
+		resp.Value = <-vchan
+		vchan <- resp.Value
+		return
+	}
+	f.cache[req.Index] = make(chan uint64, 1)
+	f.cmutex.Unlock()
+
+	v1ch := make(chan uint64)
+	go f.lookupValue(ri, req.Index-1, v1ch)
+	v2ch := make(chan uint64)
+	go f.lookupValue(ri, req.Index-2, v2ch)
+
+	resp.Value = <-v1ch
+	resp.Value += <-v2ch
+
+	f.cmutex.Lock()
+	f.cache[req.Index] <- resp.Value
+	f.cmutex.Unlock()
+
+	return
+}
+
+func (f *Fibonacci) lookupValue(ri *skynet.RequestInfo, index int, vchan chan<- uint64) {
+	var err error
+	for {
+		remoteService := f.client.GetService("Fibonacci", "", "", "")
+		req := fibonacci.Request{
+			Index: index,
+		}
+		resp := fibonacci.Response{}
+		err = remoteService.Send(ri, "Index", req, &resp)
+
+		if err == nil {
+			vchan <- resp.Value
+			return
+		}
+		f.client.Log.Item(err)
+	}
+}
+
+func main() {
+	f := NewFibonacci()
+
+	config, _ := skynet.GetServiceConfigFromFlags()
+
+	config.Name = "Fibonacci"
+	config.Version = "1"
+	config.Region = "Jersey"
+	var err error
+	mlogger, err := skynet.NewMongoLogger("localhost", "skynet", "log", config.UUID)
+	clogger := skynet.NewConsoleLogger(os.Stdout)
+	config.Log = skynet.NewMultiLogger(mlogger, clogger)
+	if err != nil {
+		config.Log.Item("Could not connect to mongo db for logging")
+	}
+	service := service.CreateService(f, config)
+
+	// handle panic so that we remove ourselves from the pool in case of catastrophic failure
+	defer func() {
+		service.Shutdown()
+		if err := recover(); err != nil {
+			log.Println("Unrecovered error occured: ", err)
+		}
+	}()
+
+	// If we pass false here service will not be Registered
+	// we could do other work/tasks by implementing the Started method and calling Register() when we're ready
+	waiter := service.Start(true)
+
+	// waiting on the sync.WaitGroup returned by service.Start() will wait for the service to finish running.
+	waiter.Wait()
+}

--- a/examples/testing/fibonacci/fibservice/fibservice.go
+++ b/examples/testing/fibonacci/fibservice/fibservice.go
@@ -77,9 +77,11 @@ func (f *Fibonacci) Index(ri *skynet.RequestInfo, req fibonacci.Request, resp *f
 }
 
 func (f *Fibonacci) lookupValue(ri *skynet.RequestInfo, index int, vchan chan<- uint64) {
+
+	remoteService := f.client.GetService("Fibonacci", "", "", "")
+
 	var err error
 	for {
-		remoteService := f.client.GetService("Fibonacci", "", "", "")
 		req := fibonacci.Request{
 			Index: index,
 		}

--- a/sky/remote.go
+++ b/sky/remote.go
@@ -43,12 +43,7 @@ func Remote(q *client.Query, args []string) {
 }
 
 func getDaemonServiceClient(q *client.Query) (c *client.Client, service *client.ServiceClient) {
-	config := &skynet.ClientConfig{
-		DoozerConfig: &skynet.DoozerConfig{
-			Uri:          "127.0.0.1:8046",
-			AutoDiscover: true,
-		},
-	}
+	config, _ := skynet.GetClientConfigFromFlags(os.Args...)
 
 	config.Log = skynet.NewConsoleLogger(os.Stderr)
 
@@ -58,7 +53,7 @@ func getDaemonServiceClient(q *client.Query) (c *client.Client, service *client.
 	query := &client.Query{
 		DoozerConn: c.DoozerConn,
 		Service:    "SkynetDaemon",
-		Host:       "127.0.0.1",
+		//Host:       "127.0.0.1",
 		Registered: &registered,
 	}
 	service = c.GetServiceFromQuery(query)


### PR DESCRIPTION
Added a service and client in examples/testing/fibonacci that can be used for sending lots of messages throughout a cluster.

I hope to keep this service/client as an example of skynet best practices. That being said, if someone comes up with some better practices, feel free to change this service.

The service will never compute the same index in the sequence twice, even if the requests come in concurrently. It sends out requests for the two previous elements to random instances in the cloud (potentially itself).

There is also a package provided that clients can use to get the appropriate types for RPC calls - a fibonacci.Request and fibonacci.Response.
