### PR TITLE
rewrite of the resource pooler

### DIFF
--- a/util/resourcepool.go
+++ b/util/resourcepool.go
@@ -1,0 +1,52 @@
+package pools
+
+type Closer interface {
+	Close()
+}
+
+type ResourcePool struct {
+	factory       Factory
+	idleResources chan Closer
+}
+
+func NewResourcePool(factory Factory, idleCapacity int) (rp *ResourcePool) {
+	rp = &ResourcePool{
+		factory:       factory,
+		idleResources: make(chan Closer, idleCapacity),
+	}
+
+	return
+}
+
+func (rp *ResourcePool) Close() {
+	close(rp.idleResources)
+}
+
+// ClaimPool() will claim all idle resources from the other pool.
+func (rp *ResourcePool) ClaimPool(o *ResourcePool) {
+	go func(o *ResourcePool) {
+		for resource := range o.idleResources {
+			rp.Release(resource)
+		}
+	}(o)
+}
+
+// AcquireOrCreate() will get one of the idle resources, or create a new one.
+func (rp *ResourcePool) AcquireOrCreate() (resource Closer, err error) {
+	select {
+	case resource = <-rp.idleResources:
+	default:
+		resource, err = rp.factory()
+	}
+	return
+}
+
+// Release() will release a resource for use by others. If the idle queue is
+// full, the resource will be closed.
+func (rp *ResourcePool) Release(resource Closer) {
+	select {
+	case rp.idleResources <- resource:
+	default:
+		resource.Close()
+	}
+}


### PR DESCRIPTION
This pull request is more of a discussion piece than something I think should go right into the code base.

It changes how the resource pooling is done in a fundamental way: you can always acquire a resource immediately - it will be taken from the idle list or it will be created on the spot. When you release a resource, it is either put in the idle list (if there is room) or closed.

If we decide that we want to put a cap on the number of connections going out from a client to a particular service, this resource pooler is the wrong way to do it (though it could be made to do it). But it will keep a set of connections available so that new ones don't need to be made constantly (and maybe in the future extra authentication and key-exchange steps can be skipped).
