### PR TITLE
instance-based pooling

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -28,6 +28,7 @@ type Service struct {
 	Config     *skynet.ServiceConfig
 	DoozerConn skynet.DoozerConnection `json:"-"`
 	Registered bool
+	Slots      int
 	doneChan   chan bool `json:"-"`
 
 	Log skynet.Logger `json:"-"`
@@ -47,6 +48,8 @@ type Service struct {
 	doozerChan   chan interface{} `json:"-"`
 	doozerWaiter sync.WaitGroup   `json:"-"`
 
+	slotsChan chan int `json:"-"`
+
 	rpcListener *net.TCPListener `json:"-"`
 }
 
@@ -62,6 +65,7 @@ func CreateService(sd ServiceDelegate, c *skynet.ServiceConfig) (s *Service) {
 		connectionChan: make(chan *net.TCPConn),
 		registeredChan: make(chan bool),
 		doozerChan:     make(chan interface{}),
+		slotsChan:      make(chan int),
 	}
 
 	c.Log.Item(ServiceCreated{
@@ -76,6 +80,10 @@ func CreateService(sd ServiceDelegate, c *skynet.ServiceConfig) (s *Service) {
 	s.RPCServ.RegisterName(s.Config.Name, rpcForwarder)
 
 	return
+}
+
+func (s *Service) AdjustSlots(slots int) {
+	s.slotsChan <- slots
 }
 
 func (s *Service) listen(addr *skynet.BindAddr) {
@@ -105,6 +113,9 @@ func (s *Service) mux() {
 loop:
 	for {
 		select {
+		case slots := <-s.slotsChan:
+			s.Slots += slots
+			s.UpdateCluster()
 		case conn := <-s.connectionChan:
 			s.activeClients.Add(1)
 

--- a/util/resourcepool.go
+++ b/util/resourcepool.go
@@ -1,0 +1,52 @@
+package pools
+
+type Closer interface {
+	Close()
+}
+
+type ResourcePool struct {
+	factory       Factory
+	idleResources chan Closer
+}
+
+func NewResourcePool(factory Factory, idleCapacity int) (rp *ResourcePool) {
+	rp = &ResourcePool{
+		factory:       factory,
+		idleResources: make(chan Closer, idleCapacity),
+	}
+
+	return
+}
+
+func (rp *ResourcePool) Close() {
+	close(rp.idleResources)
+}
+
+// ClaimPool() will claim all idle resources from the other pool.
+func (rp *ResourcePool) ClaimPool(o *ResourcePool) {
+	go func(o *ResourcePool) {
+		for resource := range o.idleResources {
+			rp.Release(resource)
+		}
+	}(o)
+}
+
+// AcquireOrCreate() will get one of the idle resources, or create a new one.
+func (rp *ResourcePool) AcquireOrCreate() (resource Closer, err error) {
+	select {
+	case resource = <-rp.idleResources:
+	default:
+		resource, err = rp.factory()
+	}
+	return
+}
+
+// Release() will release a resource for use by others. If the idle queue is
+// full, the resource will be closed.
+func (rp *ResourcePool) Release(resource Closer) {
+	select {
+	case rp.idleResources <- resource:
+	default:
+		resource.Close()
+	}
+}


### PR DESCRIPTION
this commit, which depends on the new service pooling, maintains a separate pool for each known instance. when a client tries to make an RPC call, an instance is chosen before acquiring a connection from its pool. the instance is chosen based on its self-reported "slots" metric, meant to be analogous to the number of extra requests it can currently handle.
