### PR TITLE
Removed redundant type declaration from NewMongoLogger()

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -104,7 +104,7 @@ type MongoLogger struct {
 	untransitioned *log.Logger
 }
 
-func NewMongoLogger(addr string, dbName, collectionName string, uuid string) (ml *MongoLogger, err error) {
+func NewMongoLogger(addr, dbName, collectionName, uuid string) (ml *MongoLogger, err error) {
 	ml = &MongoLogger{
 		dbName:         dbName,
 		colName:        collectionName,


### PR DESCRIPTION
Not the most epic Skynet pull request but I thought I'd clean things up while reading through everything.
