### PR TITLE
check GOBIN first

### DIFF
--- a/cmd/skydaemon/subservice.go
+++ b/cmd/skydaemon/subservice.go
@@ -68,7 +68,11 @@ func NewSubService(daemon *SkynetDaemon, servicePath, args, uuid string) (ss *Su
 	}
 
 	_, binName := path.Split(ss.ServicePath)
-	binPath := filepath.Join(pkg.BinDir, binName)
+        bindir := os.Getenv("GOBIN")
+        if bindir == "" {
+            bindir = pkg.BinDir
+        }
+	binPath := filepath.Join(bindir, binName)
 
 	ss.binPath = binPath
 


### PR DESCRIPTION
According to http://golang.org/cmd/go/#GOPATH_environment_variable :

> If the GOBIN environment variable is set, commands are installed to the directory it names instead of DIR/bin.

The command `sky deploy` should check the environment variable GOBIN first.
