### PR TITLE
Make Dashboard work with statistics in a separate doozer path

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -62,7 +62,7 @@ func NewClient(config *skynet.ClientConfig) *Client {
 
 	client.DoozerConn.Connect()
 
-	client.instanceMonitor = NewInstanceMonitor(client.DoozerConn)
+	client.instanceMonitor = NewInstanceMonitor(client.DoozerConn, false)
 
 	return client
 }

--- a/client/instancelistener.go
+++ b/client/instancelistener.go
@@ -64,14 +64,16 @@ type InstanceListener struct {
 	NotificationChan NotificationChan
 	monitor          *InstanceMonitor
 	id               string
+	includeStats     bool
 	doneInitializing chan bool
 }
 
-func NewInstanceListener(im *InstanceMonitor, id string, q *skynet.Query) *InstanceListener {
+func NewInstanceListener(im *InstanceMonitor, id string, q *skynet.Query, includeStats bool) *InstanceListener {
 	return &InstanceListener{
 		Query:            q,
 		monitor:          im,
 		id:               id,
+		includeStats:     includeStats,
 		NotificationChan: make(NotificationChan, 1),
 		doneInitializing: make(chan bool, 1),
 	}
@@ -83,6 +85,10 @@ func (l *InstanceListener) notifyEmpty() {
 }
 
 func (l *InstanceListener) notify(n InstanceMonitorNotification) {
+	if l.includeStats {
+		n.Service.FetchStats(l.monitor.doozer)
+	}
+
 	ln := NewInstanceListenerNotification(n)
 	l.notifyAux(ln)
 }

--- a/client/instancelistener.go
+++ b/client/instancelistener.go
@@ -85,7 +85,7 @@ func (l *InstanceListener) notifyEmpty() {
 }
 
 func (l *InstanceListener) notify(n InstanceMonitorNotification) {
-	if l.includeStats {
+	if l.includeStats && n.Service.Stats == nil {
 		n.Service.FetchStats(l.monitor.doozer)
 	}
 

--- a/client/instancemonitor.go
+++ b/client/instancemonitor.go
@@ -111,6 +111,10 @@ func (im *InstanceMonitor) mux() {
 			for _, s := range services {
 				path := s.GetConfigPath()
 				if listener.Query.ServiceMatches(s) {
+					if listener.includeStats {
+						s.FetchStats(im.doozer)
+					}
+
 					listener.notify(InstanceMonitorNotification{
 						Path:    path,
 						Service: s,
@@ -242,8 +246,8 @@ func (im *InstanceMonitor) buildInstanceList(l *InstanceListener) {
 	<-l.doneInitializing
 }
 
-func (im *InstanceMonitor) Listen(id string, q *skynet.Query) (l *InstanceListener) {
-	l = NewInstanceListener(im, id, q)
+func (im *InstanceMonitor) Listen(id string, q *skynet.Query, includeStats bool) (l *InstanceListener) {
+	l = NewInstanceListener(im, id, q, includeStats)
 
 	im.buildInstanceList(l)
 

--- a/client/serviceclient.go
+++ b/client/serviceclient.go
@@ -84,7 +84,7 @@ func newServiceClient(query *skynet.Query, c *Client) (sc *ServiceClient) {
 		giveupTimeout: skynet.DefaultTimeoutDuration,
 	}
 	sc.listenID = skynet.UUID()
-	sc.instanceListener = c.instanceMonitor.Listen(sc.listenID, query)
+	sc.instanceListener = c.instanceMonitor.Listen(sc.listenID, query, false)
 
 	go sc.mux()
 	return

--- a/client/serviceclient.go
+++ b/client/serviceclient.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const DEBUG = false
+const DEBUG = true
 
 func dbg(items ...interface{}) {
 	if DEBUG {
@@ -340,6 +340,9 @@ func (c *ServiceClient) attemptSend(timeout chan bool, attempts chan sendAttempt
 func (c *ServiceClient) sendToInstance(sr ServiceResource, requestInfo *skynet.RequestInfo, funcName string, in interface{}) (result []byte, serviceErr, err error) {
 	ts("sendToInstance", requestInfo)
 	defer te("sendToInstance", requestInfo)
+
+	sr.service.FetchStats(c.client.doozer())
+	dbgf("stats: %+v\n", sr.service.Stats)
 
 	sin := skynet.ServiceRPCIn{
 		RequestInfo: requestInfo,

--- a/client/serviceclient.go
+++ b/client/serviceclient.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const DEBUG = true
+const DEBUG = false
 
 func dbg(items ...interface{}) {
 	if DEBUG {

--- a/cmd/dashboard/dashboard.go
+++ b/cmd/dashboard/dashboard.go
@@ -119,7 +119,7 @@ func main() {
 	http.Handle("/favicon.ico", http.FileServer(http.Dir(*webroot+"/tmpl/images")))
 	http.Handle("/logs/ws", websocket.Handler(wsHandler))
 
-	im := client.NewInstanceMonitor(DC)
+	im := client.NewInstanceMonitor(DC, true)
 	http.Handle("/instances/ws", websocket.Handler(func(ws *websocket.Conn) {
 		NewInstanceSocket(ws, im)
 	}))

--- a/cmd/dashboard/instancesocket.go
+++ b/cmd/dashboard/instancesocket.go
@@ -44,7 +44,7 @@ func NewInstanceSocket(ws *websocket.Conn, im *client.InstanceMonitor) {
 
 	go instanceSocketRead(ws, readChan, closeChan)
 
-	l := im.Listen(skynet.UUID(), &skynet.Query{})
+	l := im.Listen(skynet.UUID(), &skynet.Query{}, true)
 
 	instances := <-l.NotificationChan
 	err := websocket.JSON.Send(ws, SocketResponse{Action: "List", Data: instances})

--- a/config.go
+++ b/config.go
@@ -129,7 +129,7 @@ type ServiceStatistics struct {
 type ServiceInfo struct {
 	Config     *ServiceConfig
 	Registered bool
-	Stats      ServiceStatistics
+	Stats      ServiceStatistics `json:"-"`
 }
 
 func (s *ServiceInfo) GetConfigPath() string {

--- a/config.go
+++ b/config.go
@@ -115,27 +115,6 @@ type ServiceConfig struct {
 	DoozerUpdateInterval time.Duration `json:"-"`
 }
 
-type ServiceStatistics struct {
-	Clients        int32
-	StartTime      string
-	LastRequest    string
-	RequestsServed int64
-
-	// For now this will be since startup, we might change it later to be for a given sample interval
-	AverageResponseTime time.Duration
-	TotalDuration       time.Duration `json:"-"`
-}
-
-type ServiceInfo struct {
-	Config     *ServiceConfig
-	Registered bool
-	Stats      ServiceStatistics `json:"-"`
-}
-
-func (s *ServiceInfo) GetConfigPath() string {
-	return "/services/" + s.Config.Name + "/" + s.Config.Version + "/" + s.Config.Region + "/" + s.Config.ServiceAddr.IPAddress + "/" + strconv.Itoa(s.Config.ServiceAddr.Port)
-}
-
 type ClientConfig struct {
 	Log                       Logger        `json:"-"`
 	DoozerConfig              *DoozerConfig `json:"-"`

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -32,5 +32,4 @@ func main() {
 	}
 
 	fmt.Println(out["data"].(string))
-
 }

--- a/examples/testing/vagranttests/vagrant.go
+++ b/examples/testing/vagranttests/vagrant.go
@@ -18,7 +18,7 @@ import (
 )
 
 var requests = flag.Int("requests", 10, "number of concurrent requests")
-var doozer = flag.String("doozer", "127.0.0.1:8046", "doozer instance to connect to")
+var doozer = flag.String("doozer", skynet.GetDefaultEnvVar("SKYNET_DZHOST", "127.0.0.1:8046"), "doozer instance to connect to")
 
 var totalRequests = expvar.NewInt("total-requests")
 var successfulRequests = expvar.NewInt("successful-requests")

--- a/query.go
+++ b/query.go
@@ -9,14 +9,24 @@ import (
 	"strings"
 )
 
+// Query is used for finding collections of service instances, according to the criteria it is given.
 type Query struct {
-	Service    string
-	Version    string
-	Host       string
-	Port       string
-	Region     string
-	UUID       string
+	// Service is the name of the service being queried. Blank for all services.
+	Service string
+	// Version is the version of the service being queried. Blank for all versions.
+	Version string
+	// Host is the host of the service being queried. Blank for all hosts.
+	Host string
+	// Port is the port of the service being queried. Blank for all ports.
+	Port string
+	// Region is the region of the service being queried. Blank for all regions.
+	Region string
+	// UUID is the UUID of the service being queried. Blank for any UUID.
+	UUID string
+
+	// Registered is the registered status of the service. Nil for any status.
 	Registered *bool
+
 	DoozerConn *DoozerConnection
 	doozerRev  int64
 

--- a/query.go
+++ b/query.go
@@ -36,7 +36,9 @@ type Query struct {
 	files      map[string]*doozer.FileInfo
 }
 
-func (q *Query) VisitDir(path string, f *doozer.FileInfo) bool {
+type queryVisitor Query
+
+func (q *queryVisitor) VisitDir(path string, f *doozer.FileInfo) bool {
 	parts := strings.Split(path, "/")
 
 	// If we know we are looking for dir's at a specified level no need to dig deeper
@@ -52,7 +54,7 @@ func (q *Query) VisitDir(path string, f *doozer.FileInfo) bool {
 	return true
 }
 
-func (q *Query) VisitFile(path string, f *doozer.FileInfo) {
+func (q *queryVisitor) VisitFile(path string, f *doozer.FileInfo) {
 	q.files[path] = f
 }
 
@@ -95,7 +97,7 @@ func (q *Query) search() {
 
 	path := q.makePath()
 
-	q.DoozerConn.Walk(q.doozerRev, path, q, nil)
+	q.DoozerConn.Walk(q.doozerRev, path, (*queryVisitor)(q), nil)
 }
 
 func (q *Query) FindHosts() []string {

--- a/query.go
+++ b/query.go
@@ -100,6 +100,7 @@ func (q *Query) search() {
 	q.DoozerConn.Walk(q.doozerRev, path, (*queryVisitor)(q), nil)
 }
 
+// *Query.FindHosts() finds all the hosts with services that match the query.
 func (q *Query) FindHosts() []string {
 	q.pathLength = 6
 	q.search()
@@ -107,6 +108,7 @@ func (q *Query) FindHosts() []string {
 	return q.matchingPaths()
 }
 
+// *Query.FindRegions() finds all the regions with services that match the query.
 func (q *Query) FindRegions() []string {
 	q.pathLength = 5
 	q.search()
@@ -114,6 +116,7 @@ func (q *Query) FindRegions() []string {
 	return q.matchingPaths()
 }
 
+// *Query.FindServices() finds paths for all the services that match the query.
 func (q *Query) FindServices() []string {
 	q.pathLength = 3
 	q.search()
@@ -121,6 +124,7 @@ func (q *Query) FindServices() []string {
 	return q.matchingPaths()
 }
 
+// *Query.FindServiceVersions finds all the versions with services that match the query.
 func (q *Query) FindServiceVersions() []string {
 	q.pathLength = 4
 	q.search()
@@ -128,6 +132,7 @@ func (q *Query) FindServiceVersions() []string {
 	return q.matchingPaths()
 }
 
+// *Query.FindInstances fetches the services that match the query.
 func (q *Query) FindInstances() []*ServiceInfo {
 	q.search()
 
@@ -236,6 +241,7 @@ func (q *Query) pathMatches(path string) bool {
 	return true
 }
 
+// *Query.ServiceMatches indicates if the query matches the given service.
 func (q *Query) ServiceMatches(s ServiceInfo) bool {
 	if q.Service != "" && s.Config.Name != q.Service {
 		return false
@@ -268,6 +274,7 @@ func (q *Query) ServiceMatches(s ServiceInfo) bool {
 	return true
 }
 
+// *Query.Reset erases this query, making it match all services until fields are set.
 func (q *Query) Reset() {
 	q.Service = ""
 	q.Version = ""

--- a/requestinfo.go
+++ b/requestinfo.go
@@ -1,5 +1,6 @@
 package skynet
 
+// RequestInfo is information about a request, and is provided to every skynet RPC call.
 type RequestInfo struct {
 	// OriginAddress is the reported address of the originating client, typically from outside the service cluster.
 	OriginAddress string

--- a/service/service.go
+++ b/service/service.go
@@ -190,7 +190,6 @@ loop:
 			break loop
 
 		case _ = <-s.updateTicker.C:
-			s.UpdateDoozerServiceInfo()
 			s.UpdateDoozerStats()
 		}
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -328,7 +328,13 @@ func (s *Service) cleanupDoozerEntriesForAddr(addr *skynet.BindAddr) {
 }
 
 func (s *Service) UpdateDoozerServiceInfo() {
-	b, err := json.Marshal(s.ServiceInfo)
+
+	// We're going to create a copy of our ServiceInfo so that we can nil out the Stats, which will match the omitempty and won't marshal 
+	// this is cheap as it's a single bool, and 2 pointers.
+	si := s.ServiceInfo
+	si.Stats = nil
+
+	b, err := json.Marshal(si)
 	if err != nil {
 		s.Log.Panic(err.Error())
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -411,12 +411,19 @@ func initializeConfig(c *skynet.ServiceConfig) {
 		c.Region = "local"
 	}
 
+	if c.ServiceAddr == nil {
+		c.ServiceAddr = &skynet.BindAddr{}
+	}
+
 	if c.ServiceAddr.IPAddress == "" {
 		c.ServiceAddr.IPAddress = "127.0.0.1"
 	}
 
 	if c.ServiceAddr.Port == 0 {
 		c.ServiceAddr.Port = 9000
+	}
+	if c.ServiceAddr.MaxPort == 0 {
+		c.ServiceAddr.MaxPort = 9999
 	}
 
 	if c.DoozerConfig == nil {

--- a/service/service.go
+++ b/service/service.go
@@ -79,7 +79,7 @@ func CreateService(sd ServiceDelegate, c *skynet.ServiceConfig) (s *Service) {
 	}
 
 	s.Config = c
-	s.Stats = skynet.ServiceStatistics{
+	s.Stats = &skynet.ServiceStatistics{
 		StartTime: time.Now().Format("2006-01-02T15:04:05Z-0700"),
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -190,7 +190,8 @@ loop:
 			break loop
 
 		case _ = <-s.updateTicker.C:
-			s.UpdateCluster()
+			s.UpdateDoozerServiceInfo()
+			s.UpdateDoozerStats()
 		}
 	}
 }
@@ -286,7 +287,7 @@ func (s *Service) Start(register bool) (done *sync.WaitGroup) {
 	s.doozerWaiter.Add(1)
 	go s.doozerMux()
 
-	s.UpdateCluster()
+	s.UpdateDoozerServiceInfo()
 
 	if register == true {
 		s.register()
@@ -320,7 +321,7 @@ func (s *Service) cleanupDoozerEntriesForAddr(addr *skynet.BindAddr) {
 	}
 }
 
-func (s *Service) UpdateCluster() {
+func (s *Service) UpdateDoozerServiceInfo() {
 	b, err := json.Marshal(s.ServiceInfo)
 	if err != nil {
 		s.Log.Panic(err.Error())
@@ -329,6 +330,17 @@ func (s *Service) UpdateCluster() {
 
 	s.doozerChan <- doozerSetConfig{
 		ConfigPath: cfgpath,
+		ConfigData: b,
+	}
+}
+
+func (s *Service) UpdateDoozerStats() {
+	b, err := json.Marshal(s.ServiceInfo.Stats)
+	if err != nil {
+		s.Log.Panic(err.Error())
+	}
+	s.doozerChan <- doozerSetConfig{
+		ConfigPath: s.GetStatsPath(),
 		ConfigData: b,
 	}
 }
@@ -346,7 +358,7 @@ func (s *Service) register() {
 	}
 	s.Registered = true
 	s.Log.Item(ServiceRegistered{s.Config})
-	s.UpdateCluster()
+	s.UpdateDoozerServiceInfo()
 	s.Delegate.Registered(s) // Call user defined callback
 }
 
@@ -361,7 +373,7 @@ func (s *Service) unregister() {
 	}
 	s.Registered = false
 	s.Log.Item(ServiceUnregistered{s.Config})
-	s.UpdateCluster()
+	s.UpdateDoozerServiceInfo()
 	s.Delegate.Unregistered(s) // Call user defined callback
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -202,6 +202,7 @@ type doozerSetConfig struct {
 
 type doozerRemoveFromCluster struct {
 	ConfigPath string
+	StatsPath  string
 }
 
 type doozerFinish struct{}
@@ -219,6 +220,11 @@ loop:
 		case doozerRemoveFromCluster:
 			rev := s.doozer().GetCurrentRevision()
 			err := s.doozer().Del(i.ConfigPath, rev)
+			if err != nil {
+				s.Log.Panic(err.Error())
+			}
+
+			err = s.doozer().Del(i.StatsPath, rev)
 			if err != nil {
 				s.Log.Panic(err.Error())
 			}
@@ -317,6 +323,7 @@ func (s *Service) cleanupDoozerEntriesForAddr(addr *skynet.BindAddr) {
 	for _, i := range instances {
 		s.Log.Item("Cleaning up old doozer entry with conflicting addr " + addr.String() + "(" + i.GetConfigPath() + ")")
 		s.doozer().Del(i.GetConfigPath(), s.doozer().GetCurrentRevision())
+		s.doozer().Del(i.GetStatsPath(), s.doozer().GetCurrentRevision())
 	}
 }
 
@@ -347,6 +354,7 @@ func (s *Service) UpdateDoozerStats() {
 func (s *Service) RemoveFromCluster() {
 	s.doozerChan <- doozerRemoveFromCluster{
 		ConfigPath: s.GetConfigPath(),
+		StatsPath:  s.GetStatsPath(),
 	}
 }
 

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -33,7 +33,7 @@ type ServiceInfo struct {
 	// Registered indicates if the instance is currently accepting requests.
 	Registered bool
 	// Stats is transient data about instance load and other things.
-	Stats *ServiceStatistics `json:"-"`
+	Stats *ServiceStatistics `json:",omitempty"`
 }
 
 // *ServiceInfo.GetConfigPath() returns the doozer path where it's stored. The statistics are not included.

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -1,0 +1,33 @@
+package skynet
+
+import (
+	"path"
+	"strconv"
+	"time"
+)
+
+type ServiceStatistics struct {
+	Clients        int32
+	StartTime      string
+	LastRequest    string
+	RequestsServed int64
+
+	// For now this will be since startup, we might change it later to be for a given sample interval
+	AverageResponseTime time.Duration
+	TotalDuration       time.Duration `json:"-"`
+}
+
+type ServiceInfo struct {
+	Config     *ServiceConfig
+	Registered bool
+	Stats      ServiceStatistics `json:"-"`
+}
+
+func (s *ServiceInfo) GetConfigPath() string {
+	//	return "/services/" + s.Config.Name + "/" + s.Config.Version + "/" + s.Config.Region + "/" + s.Config.ServiceAddr.IPAddress + "/" + strconv.Itoa(s.Config.ServiceAddr.Port)
+	return path.Join("/services", s.Config.Name, s.Config.Version, s.Config.Region, s.Config.ServiceAddr.IPAddress, strconv.Itoa(s.Config.ServiceAddr.Port))
+}
+
+func (s *ServiceInfo) GetStatsPath() string {
+	return path.Join("/statistics", s.Config.Name, s.Config.Version, s.Config.Region, s.Config.ServiceAddr.IPAddress, strconv.Itoa(s.Config.ServiceAddr.Port))
+}

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -7,34 +7,46 @@ import (
 	"time"
 )
 
+// ServiceStatistics contains information about its service that can be used to estimate load.
 type ServiceStatistics struct {
-	Clients        int32
-	StartTime      string
-	LastRequest    string
+	// Clients is the number of clients currently connected to this service.
+	Clients int32
+	// StartTime is the time when the service began running.
+	StartTime string
+	// LastRequest is the time when the last request was made.
+	LastRequest string
+	// RequestsServed is the number of requests served by this service since it began.
 	RequestsServed int64
 
-	// For now this will be since startup, we might change it later to be for a given sample interval
+	// AverageResponseTime is the average time taken to respond to a request, since startup.
+	// Note: in the future, this may be the average over some sliding window.
 	AverageResponseTime time.Duration
-	TotalDuration       time.Duration `json:"-"`
+
+	// TotalDuration is the total time taken by all requests made to this service.
+	TotalDuration time.Duration `json:"-"`
 }
 
+// ServiceInfo is the publicly reported information about a particular service instance.
 type ServiceInfo struct {
-	Config     *ServiceConfig
+	// Config is the configuration used to start this instance.
+	Config *ServiceConfig
+	// Registered indicates if the instance is currently accepting requests.
 	Registered bool
-	Stats      ServiceStatistics `json:"-"`
+	// Stats is transient data about instance load and other things.
+	Stats ServiceStatistics `json:"-"`
 }
 
+// *ServiceInfo.GetConfigPath() returns the doozer path where it's stored. The statistics are not included.
 func (s *ServiceInfo) GetConfigPath() string {
 	return path.Join("/services", s.Config.Name, s.Config.Version, s.Config.Region, s.Config.ServiceAddr.IPAddress, strconv.Itoa(s.Config.ServiceAddr.Port))
 }
 
+// *ServiceInfo.GetStatsPath() returns the doozer path where it's statistics are stored.
 func (s *ServiceInfo) GetStatsPath() string {
 	return path.Join("/statistics", s.Config.Name, s.Config.Version, s.Config.Region, s.Config.ServiceAddr.IPAddress, strconv.Itoa(s.Config.ServiceAddr.Port))
 }
 
-/*
-*ServiceInfo.FetchStats will query the provided doozer connection and update its .Stats field.
- */
+// *ServiceInfo.FetchStats will query the provided doozer connection and update its .Stats field. 
 func (s *ServiceInfo) FetchStats(doozer *DoozerConnection) (err error) {
 	rev := doozer.GetCurrentRevision()
 	data, _, err := doozer.Get(s.GetStatsPath(), rev)

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -1,6 +1,7 @@
 package skynet
 
 import (
+	"encoding/json"
 	"path"
 	"strconv"
 	"time"
@@ -30,4 +31,17 @@ func (s *ServiceInfo) GetConfigPath() string {
 
 func (s *ServiceInfo) GetStatsPath() string {
 	return path.Join("/statistics", s.Config.Name, s.Config.Version, s.Config.Region, s.Config.ServiceAddr.IPAddress, strconv.Itoa(s.Config.ServiceAddr.Port))
+}
+
+func (s *ServiceInfo) FetchStats(doozer *DoozerConnection) (err error) {
+	rev := doozer.GetCurrentRevision()
+	data, _, err := doozer.Get(s.GetStatsPath(), rev)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(data, s)
+	if err != nil {
+		return
+	}
+	return
 }

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -57,7 +57,7 @@ func (s *ServiceInfo) FetchStats(doozer *DoozerConnection) (err error) {
 	if err != nil {
 		return
 	}
-	err = json.Unmarshal(data, &s.Stats)
+	err = json.Unmarshal(data, s.Stats)
 	if err != nil {
 		return
 	}

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -48,10 +48,6 @@ func (s *ServiceInfo) GetStatsPath() string {
 
 // *ServiceInfo.FetchStats will query the provided doozer connection and update its .Stats field. 
 func (s *ServiceInfo) FetchStats(doozer *DoozerConnection) (err error) {
-	if s.Stats != nil {
-		return
-	}
-
 	rev := doozer.GetCurrentRevision()
 	data, _, err := doozer.Get(s.GetStatsPath(), rev)
 	if err != nil {

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -33,7 +33,7 @@ type ServiceInfo struct {
 	// Registered indicates if the instance is currently accepting requests.
 	Registered bool
 	// Stats is transient data about instance load and other things.
-	Stats ServiceStatistics `json:"-"`
+	Stats *ServiceStatistics `json:"-"`
 }
 
 // *ServiceInfo.GetConfigPath() returns the doozer path where it's stored. The statistics are not included.
@@ -48,6 +48,10 @@ func (s *ServiceInfo) GetStatsPath() string {
 
 // *ServiceInfo.FetchStats will query the provided doozer connection and update its .Stats field. 
 func (s *ServiceInfo) FetchStats(doozer *DoozerConnection) (err error) {
+	if s.Stats != nil {
+		return
+	}
+
 	rev := doozer.GetCurrentRevision()
 	data, _, err := doozer.Get(s.GetStatsPath(), rev)
 	if err != nil {

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -57,7 +57,7 @@ func (s *ServiceInfo) FetchStats(doozer *DoozerConnection) (err error) {
 	if err != nil {
 		return
 	}
-	err = json.Unmarshal(data, s.Stats)
+	err = json.Unmarshal(data, &s.Stats)
 	if err != nil {
 		return
 	}

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -39,7 +39,7 @@ func (s *ServiceInfo) FetchStats(doozer *DoozerConnection) (err error) {
 	if err != nil {
 		return
 	}
-	err = json.Unmarshal(data, s)
+	err = json.Unmarshal(data, &s.Stats)
 	if err != nil {
 		return
 	}

--- a/serviceinfo.go
+++ b/serviceinfo.go
@@ -25,7 +25,6 @@ type ServiceInfo struct {
 }
 
 func (s *ServiceInfo) GetConfigPath() string {
-	//	return "/services/" + s.Config.Name + "/" + s.Config.Version + "/" + s.Config.Region + "/" + s.Config.ServiceAddr.IPAddress + "/" + strconv.Itoa(s.Config.ServiceAddr.Port)
 	return path.Join("/services", s.Config.Name, s.Config.Version, s.Config.Region, s.Config.ServiceAddr.IPAddress, strconv.Itoa(s.Config.ServiceAddr.Port))
 }
 
@@ -33,6 +32,9 @@ func (s *ServiceInfo) GetStatsPath() string {
 	return path.Join("/statistics", s.Config.Name, s.Config.Version, s.Config.Region, s.Config.ServiceAddr.IPAddress, strconv.Itoa(s.Config.ServiceAddr.Port))
 }
 
+/*
+*ServiceInfo.FetchStats will query the provided doozer connection and update its .Stats field.
+ */
 func (s *ServiceInfo) FetchStats(doozer *DoozerConnection) (err error) {
 	rev := doozer.GetCurrentRevision()
 	data, _, err := doozer.Get(s.GetStatsPath(), rev)

--- a/uuid.go
+++ b/uuid.go
@@ -7,6 +7,7 @@ import (
 	"log"
 )
 
+// UUID() provides unique identifier strings.
 func UUID() string {
 	b := make([]byte, 16)
 	_, err := io.ReadFull(rand.Reader, b)


### PR DESCRIPTION
Modified InstanceMonitor/InstanceListener to take an optional flag to include statistics, and be notified of statistics changes.

This makes dashboard work as it always has, with update notifications that include the statistics, as well as normal InstanceUpdateNotifications when statistics change.

All the logic is tucked away in InstanceMonitor and InstanceListener so that you just need to enable your instance monitor to watch for statistics changes, and your listeners to tell the monitor that it want's to include statistics.

Normal clients versions of the instance monitor only monitor for ServiceInfo changes, and don't even bother watching the Statistics doozer path.
