### PR TITLE
the `ServiceDelegate.Stopped` will be called twice

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -404,7 +404,10 @@ func (s *Service) Shutdown() {
 	s.activeRequests.Wait()
 	s.doozerWaiter.Wait()
 
-	s.Delegate.Stopped(s) // Call user defined callback
+        if s.Delegate != nil {
+	    s.Delegate.Stopped(s) // Call user defined callback
+            s.Delegate = nil
+        }
 
 	s.doneGroup.Done()
 }


### PR DESCRIPTION
According to https://github.com/bketelsen/skynet/wiki/Service-Tutorial, `service.Shutdown` will be call in main.main's defer function. Is it a good practice, right?

But in the source https://github.com/bketelsen/skynet/blob/master/service/service.go, line 472, function `watchSignals` was called the Shutdown when captured a signal.

So, the `ServiceDelegate.Stopped` will be called twice.

This patch fixed that issue.
