### PR TITLE
Allow skydaemon to take an optional flag for which mongodb server to connect to

### DIFF
--- a/cmd/skydaemon/main.go
+++ b/cmd/skydaemon/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"errors"
-	"flag"
 	"github.com/bketelsen/skynet"
 	"github.com/bketelsen/skynet/daemon"
 	"github.com/bketelsen/skynet/service"
@@ -21,16 +20,7 @@ import (
 // Daemon will run the "SkynetDeployment" service, which can be used
 // to remotely spawn new services on the host.
 func main() {
-	flagset := flag.NewFlagSet("skydaemon", flag.ExitOnError)
-	mgoserver := flagset.String("mgoserver",
-		skynet.GetDefaultEnvVar("SKYNET_MGOSERVER", ""),
-		"comma-separated list of urls of mongodb servers")
-	config := &skynet.ServiceConfig{
-		DoozerConfig: &skynet.DoozerConfig{},
-	}
-
-	skynet.FlagsForService(config, flagset)
-	config, args := skynet.ParseServiceFlags(config, flagset, os.Args)
+	config, args := skynet.GetServiceConfig()
 
 	config.Name = "SkynetDaemon"
 	config.Version = "1"
@@ -39,7 +29,7 @@ func main() {
 	config.AdminAddr = nil
 
 	var err error
-	mlogger, err := skynet.NewMongoSemanticLogger(*mgoserver, "skynet",
+	mlogger, err := skynet.NewMongoSemanticLogger(config.MongoConfig.MongoHosts, "skynet",
 		"log", config.UUID)
 	clogger := skynet.NewConsoleSemanticLogger("skydaemon", os.Stdout)
 	config.Log = skynet.NewMultiSemanticLogger(mlogger, clogger)

--- a/config.go
+++ b/config.go
@@ -195,15 +195,7 @@ func GetServiceConfig() (config *ServiceConfig, args []string) {
 	return GetServiceConfigFromFlags(os.Args[1:])
 }
 
-func GetServiceConfigFromFlags(argv []string) (config *ServiceConfig, args []string) {
-
-	config = &ServiceConfig{
-		DoozerConfig: &DoozerConfig{},
-	}
-
-	flagset := flag.NewFlagSet("config", flag.ContinueOnError)
-
-	FlagsForService(config, flagset)
+func ParseServiceFlags(scfg *ServiceConfig, flagset *flag.FlagSet, argv []string) (config *ServiceConfig, args []string) {
 
 	rpcAddr := flagset.String("l", GetDefaultBindAddr(), "host:port to listen on for RPC")
 	adminAddr := flagset.String("admin", GetDefaultBindAddr(), "host:port to listen on for admin")
@@ -225,8 +217,21 @@ func GetServiceConfigFromFlags(argv []string) (config *ServiceConfig, args []str
 		panic(err)
 	}
 
-	config.ServiceAddr = rpcBA
-	config.AdminAddr = adminBA
+	scfg.ServiceAddr = rpcBA
+	scfg.AdminAddr = adminBA
 
-	return
+	return scfg, args
+}
+
+func GetServiceConfigFromFlags(argv []string) (config *ServiceConfig, args []string) {
+
+	config = &ServiceConfig{
+		DoozerConfig: &DoozerConfig{},
+	}
+
+	flagset := flag.NewFlagSet("config", flag.ContinueOnError)
+
+	FlagsForService(config, flagset)
+
+	return ParseServiceFlags(config, flagset, argv)
 }

--- a/documentation/contributors.txt
+++ b/documentation/contributors.txt
@@ -6,3 +6,4 @@ John Asmuth       jasmuth@gmail.com
 Xing Xing         mikespook@gmail.com
 Reid Morrison     reidmo@gmail.com
 Steve Phillips    elimisteve@gmail.com
+Leo Franchi       lfranchi@kde.org

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -139,7 +139,7 @@ Vagrant::Config.run do |config|
       c.vm.provision :shell, :inline => "nohup doozerd -timeout 5 -l '192.168.126.10#{i}:8046' -w '192.168.126.10#{i}:8080' -c 'skynet' -b 'doozer:?ca=192.168.126.101:10000' 0<&- &> /var/log/doozer.log &"
 
       # Start Daemon
-      c.vm.provision :shell, :inline => "nohup /opt/local/gopath/bin/skydaemon --version=1 0<&- &> /var/log/skynet_daemon.log &"
+      c.vm.provision :shell, :inline => "nohup /opt/local/gopath/bin/skydaemon -mgoserver='192.168.126.101:27017' --version=1 0<&- &> /var/log/skynet_daemon.log &"
 
       # Start Services
       c.vm.provision :shell, :inline => "sleep 15 && sky --host=192.168.126.10#{i} deploy github.com/bketelsen/skynet/examples/service --version=1"


### PR DESCRIPTION
This is my first pull request so feel free to let me know what I've done wrong :) I tried to keep the code duplication down by splitting GetServiceConfigFromFlags into two.

I was having issues with the default Vagrantfile setup with all the non-main VMs trying to connect to a mongo on localhost that was hardcoded---the mongo server is only running on one of the 5 vms.

cheers,
leo
