### PR TITLE
Prevent panic when no command line args given

### DIFF
--- a/cmd/sky/sky.go
+++ b/cmd/sky/sky.go
@@ -46,6 +46,12 @@ func main() {
 		Port:       *PortFlag,
 	}
 
+	// Runs when no command line arguments were given
+	if len(args) == 0 {
+		CommandLineHelp()
+		return
+	}
+
 	fmt.Println(args[0])
 
 	switch args[0] {


### PR DESCRIPTION
Fixes https://github.com/skynetservices/skynet/issues/183
