### PR TITLE
Prevent runtime panic with topology

### DIFF
--- a/cmd/sky/sky.go
+++ b/cmd/sky/sky.go
@@ -187,6 +187,10 @@ func PrintTopology(q *skynet.Query) {
 
 	// Build topology hash first
 	for _, instance := range results {
+		// Prevent runtime nil pointer dereference
+		if instance.Config == nil {
+			continue
+		}
 		if topology[instance.Config.Region] == nil {
 			topology[instance.Config.Region] = make(map[string]map[string]map[string][]*skynet.ServiceInfo)
 		}


### PR DESCRIPTION
When a service is deployed to doozer with a different region (like "unknown"
because you forgot to set SKYNET_REGION) then stopped, the instance is just
the zero-value and will cause:

panic: runtime error: invalid memory address or nil pointer dereference
